### PR TITLE
Disable the special modulus and export noise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ sunscreen ]
+  pull_request:
+    branches: [ sunscreen ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: Build SEAL
+      run: |
+        cmake -S . -B build -DSEAL_BUILD_EXAMPLES=ON -DSEAL_BUILD_TESTS=ON -DSEAL_THROW_ON_TRANSPARENT_CIPHERTEXT=ON -DSEAL_BUILD_SEAL_C=ON
+        cmake --build build
+
+    - name: Run tests
+      run: ./build/bin/sealtest

--- a/native/src/seal/CMakeLists.txt
+++ b/native/src/seal/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SEAL_SOURCE_FILES ${SEAL_SOURCE_FILES}
     ${CMAKE_CURRENT_LIST_DIR}/memorymanager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/modulus.cpp
     ${CMAKE_CURRENT_LIST_DIR}/plaintext.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/polyarray.cpp
     ${CMAKE_CURRENT_LIST_DIR}/randomgen.cpp
     ${CMAKE_CURRENT_LIST_DIR}/serialization.cpp
     ${CMAKE_CURRENT_LIST_DIR}/valcheck.cpp
@@ -39,6 +40,7 @@ install(
         ${CMAKE_CURRENT_LIST_DIR}/kswitchkeys.h
         ${CMAKE_CURRENT_LIST_DIR}/memorymanager.h
         ${CMAKE_CURRENT_LIST_DIR}/plaintext.h
+        ${CMAKE_CURRENT_LIST_DIR}/polyarray.h
         ${CMAKE_CURRENT_LIST_DIR}/publickey.h
         ${CMAKE_CURRENT_LIST_DIR}/randomgen.h
         ${CMAKE_CURRENT_LIST_DIR}/randomtostd.h

--- a/native/src/seal/c/CMakeLists.txt
+++ b/native/src/seal/c/CMakeLists.txt
@@ -19,8 +19,10 @@ target_sources(sealc PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/memorypoolhandle.cpp
     ${CMAKE_CURRENT_LIST_DIR}/modulus.cpp
     ${CMAKE_CURRENT_LIST_DIR}/plaintext.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/polyarray.cpp
     ${CMAKE_CURRENT_LIST_DIR}/publickey.cpp
     ${CMAKE_CURRENT_LIST_DIR}/relinkeys.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/rns.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sealcontext.cpp
     ${CMAKE_CURRENT_LIST_DIR}/secretkey.cpp
     ${CMAKE_CURRENT_LIST_DIR}/serialization.cpp
@@ -49,8 +51,10 @@ install(
         ${CMAKE_CURRENT_LIST_DIR}/memorypoolhandle.h
         ${CMAKE_CURRENT_LIST_DIR}/modulus.h
         ${CMAKE_CURRENT_LIST_DIR}/plaintext.h
+        ${CMAKE_CURRENT_LIST_DIR}/polyarray.h
         ${CMAKE_CURRENT_LIST_DIR}/publickey.h
         ${CMAKE_CURRENT_LIST_DIR}/relinkeys.h
+        ${CMAKE_CURRENT_LIST_DIR}/rns.h
         ${CMAKE_CURRENT_LIST_DIR}/sealcontext.h
         ${CMAKE_CURRENT_LIST_DIR}/secretkey.h
         ${CMAKE_CURRENT_LIST_DIR}/serialization.h

--- a/native/src/seal/c/encryptor.cpp
+++ b/native/src/seal/c/encryptor.cpp
@@ -131,6 +131,44 @@ SEAL_C_FUNC Encryptor_Encrypt(void *thisptr, void *plaintext, void *destination,
     }
 }
 
+
+SEAL_C_FUNC Encryptor_EncryptReturnComponents(
+    void *thisptr, 
+    void *plaintext, 
+    bool disable_special_modulus, 
+    void *destination, 
+    void *u_destination, 
+    void *e_destination, 
+    void *pool_handle) 
+{
+    Encryptor *encryptor = FromVoid<Encryptor>(thisptr);
+    IfNullRet(encryptor, E_POINTER);
+    Plaintext *plain = FromVoid<Plaintext>(plaintext);
+    IfNullRet(plain, E_POINTER);
+    Ciphertext *cipher = FromVoid<Ciphertext>(destination);
+    IfNullRet(cipher, E_POINTER);
+    StaticPolynomialArray *u_dest = FromVoid<StaticPolynomialArray>(u_destination);
+    IfNullRet(u_dest, E_POINTER);
+    StaticPolynomialArray *e_dest = FromVoid<StaticPolynomialArray>(e_destination);
+    IfNullRet(e_dest, E_POINTER);
+    unique_ptr<MemoryPoolHandle> pool = MemHandleFromVoid(pool_handle);
+
+    try
+    {
+        encryptor->encrypt(*plain, disable_special_modulus, *cipher, *u_dest, *e_dest, *pool);
+        return S_OK;
+    }
+    catch (const invalid_argument &)
+    {
+        return E_INVALIDARG;
+    }
+    catch (const logic_error &)
+    {
+        return COR_E_INVALIDOPERATION;
+    }
+
+}
+
 SEAL_C_FUNC Encryptor_EncryptZero1(void *thisptr, uint64_t *parms_id, void *destination, void *pool_handle)
 {
     Encryptor *encryptor = FromVoid<Encryptor>(thisptr);

--- a/native/src/seal/c/encryptor.cpp
+++ b/native/src/seal/c/encryptor.cpp
@@ -147,9 +147,9 @@ SEAL_C_FUNC Encryptor_EncryptReturnComponents(
     IfNullRet(plain, E_POINTER);
     Ciphertext *cipher = FromVoid<Ciphertext>(destination);
     IfNullRet(cipher, E_POINTER);
-    StaticPolynomialArray *u_dest = FromVoid<StaticPolynomialArray>(u_destination);
+    PolynomialArray *u_dest = FromVoid<PolynomialArray>(u_destination);
     IfNullRet(u_dest, E_POINTER);
-    StaticPolynomialArray *e_dest = FromVoid<StaticPolynomialArray>(e_destination);
+    PolynomialArray *e_dest = FromVoid<PolynomialArray>(e_destination);
     IfNullRet(e_dest, E_POINTER);
     unique_ptr<MemoryPoolHandle> pool = MemHandleFromVoid(pool_handle);
 

--- a/native/src/seal/c/encryptor.h
+++ b/native/src/seal/c/encryptor.h
@@ -21,6 +21,9 @@ SEAL_C_FUNC Encryptor_SetSecretKey(void *thisptr, void *secret_key);
 
 SEAL_C_FUNC Encryptor_Encrypt(void *thisptr, void *plaintext, void *destination, void *pool_handle);
 
+SEAL_C_FUNC Encryptor_EncryptReturnComponents(
+    void *thisptr, void *plaintext, bool disable_special_modulus, void *destination, void *u_destination, void *e_destination, void *pool_handle);
+
 SEAL_C_FUNC Encryptor_EncryptZero1(void *thisptr, uint64_t *parms_id, void *destination, void *pool_handle);
 
 SEAL_C_FUNC Encryptor_EncryptZero2(void *thisptr, void *destination, void *pool_handle);

--- a/native/src/seal/c/polyarray.cpp
+++ b/native/src/seal/c/polyarray.cpp
@@ -14,14 +14,14 @@ using namespace seal::util;
 
 
 
-SEAL_C_FUNC StaticPolynomialArray_Create(void *memoryPoolHandle, void **poly_array)
+SEAL_C_FUNC PolynomialArray_Create(void *memoryPoolHandle, void **poly_array)
 {
     IfNullRet(poly_array, E_POINTER);
     unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
 
     try
     {
-        StaticPolynomialArray *array = new StaticPolynomialArray(*handle);
+        PolynomialArray *array = new PolynomialArray(*handle);
         *poly_array = array;
         return S_OK;
     }
@@ -31,7 +31,7 @@ SEAL_C_FUNC StaticPolynomialArray_Create(void *memoryPoolHandle, void **poly_arr
     }
 }
 
-SEAL_C_FUNC StaticPolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *context, void *ciphertext, void **poly_array)
+SEAL_C_FUNC PolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *context, void *ciphertext, void **poly_array)
 {
     const SEALContext *ctx = FromVoid<SEALContext>(context);
     IfNullRet(ctx, E_POINTER);
@@ -44,7 +44,7 @@ SEAL_C_FUNC StaticPolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, v
 
     try
     {
-        StaticPolynomialArray *array = new StaticPolynomialArray(*ctx, *cipher, *handle);
+        PolynomialArray *array = new PolynomialArray(*ctx, *cipher, *handle);
         *poly_array = array;
         return S_OK;
     }
@@ -54,7 +54,7 @@ SEAL_C_FUNC StaticPolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, v
     }
 }
 
-SEAL_C_FUNC StaticPolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array)
+SEAL_C_FUNC PolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array)
 {
     const SEALContext *ctx = FromVoid<SEALContext>(context);
     IfNullRet(ctx, E_POINTER);
@@ -67,7 +67,7 @@ SEAL_C_FUNC StaticPolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, vo
 
     try
     {
-        StaticPolynomialArray *array = new StaticPolynomialArray(*ctx, *pk, *handle);
+        PolynomialArray *array = new PolynomialArray(*ctx, *pk, *handle);
         *poly_array = array;
         return S_OK;
     }
@@ -77,18 +77,18 @@ SEAL_C_FUNC StaticPolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, vo
     }
 }
 
-SEAL_C_FUNC StaticPolynomialArray_Destroy(void *thisptr)
+SEAL_C_FUNC PolynomialArray_Destroy(void *thisptr)
 {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
 
     delete poly_array;
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_IsReserved(void *thisptr, bool *is_reserved)
+SEAL_C_FUNC PolynomialArray_IsReserved(void *thisptr, bool *is_reserved)
 {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(is_reserved, E_POINTER);
 
@@ -96,9 +96,9 @@ SEAL_C_FUNC StaticPolynomialArray_IsReserved(void *thisptr, bool *is_reserved)
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_IsRns(void *thisptr, bool *is_rns)
+SEAL_C_FUNC PolynomialArray_IsRns(void *thisptr, bool *is_rns)
 {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(is_rns, E_POINTER);
 
@@ -106,9 +106,9 @@ SEAL_C_FUNC StaticPolynomialArray_IsRns(void *thisptr, bool *is_rns)
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_IsMultiprecision(void *thisptr, bool *is_multiprecision)
+SEAL_C_FUNC PolynomialArray_IsMultiprecision(void *thisptr, bool *is_multiprecision)
 {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(is_multiprecision, E_POINTER);
 
@@ -116,8 +116,8 @@ SEAL_C_FUNC StaticPolynomialArray_IsMultiprecision(void *thisptr, bool *is_multi
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_ToRns(void *thisptr) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_ToRns(void *thisptr) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
 
     poly_array->to_rns();
@@ -125,8 +125,8 @@ SEAL_C_FUNC StaticPolynomialArray_ToRns(void *thisptr) {
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_ToMultiprecision(void *thisptr) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_ToMultiprecision(void *thisptr) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
 
     poly_array->to_multiprecision();
@@ -135,8 +135,8 @@ SEAL_C_FUNC StaticPolynomialArray_ToMultiprecision(void *thisptr) {
 
 }
 
-SEAL_C_FUNC StaticPolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_index, uint64_t *data){
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_index, uint64_t *data){
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(data, E_POINTER);
 
@@ -151,8 +151,8 @@ SEAL_C_FUNC StaticPolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_ind
     }
 }
 
-SEAL_C_FUNC StaticPolynomialArray_ExportSize(void *thisptr, uint64_t *size) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_ExportSize(void *thisptr, uint64_t *size) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(size, E_POINTER);
 
@@ -160,8 +160,8 @@ SEAL_C_FUNC StaticPolynomialArray_ExportSize(void *thisptr, uint64_t *size) {
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_PerformExport(void *thisptr, uint64_t *data) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_PerformExport(void *thisptr, uint64_t *data) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(data, E_POINTER);
 
@@ -170,8 +170,8 @@ SEAL_C_FUNC StaticPolynomialArray_PerformExport(void *thisptr, uint64_t *data) {
 }
 
 
-SEAL_C_FUNC StaticPolynomialArray_PolySize(void *thisptr, uint64_t *size) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_PolySize(void *thisptr, uint64_t *size) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(size, E_POINTER);
 
@@ -179,8 +179,8 @@ SEAL_C_FUNC StaticPolynomialArray_PolySize(void *thisptr, uint64_t *size) {
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(size, E_POINTER);
 
@@ -188,8 +188,8 @@ SEAL_C_FUNC StaticPolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *siz
     return S_OK;
 }
 
-SEAL_C_FUNC StaticPolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size) {
-    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+SEAL_C_FUNC PolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size) {
+    PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);
     IfNullRet(poly_array, E_POINTER);
     IfNullRet(size, E_POINTER);
 

--- a/native/src/seal/c/polyarray.cpp
+++ b/native/src/seal/c/polyarray.cpp
@@ -1,0 +1,198 @@
+// SEALNet
+#include "seal/c/rns.h"
+#include "seal/c/utilities.h"
+
+// SEAL
+#include "seal/ciphertext.h"
+#include "seal/polyarray.h"
+#include "seal/c/polyarray.h"
+
+using namespace std;
+using namespace seal;
+using namespace seal::c;
+using namespace seal::util;
+
+
+
+SEAL_C_FUNC StaticPolynomialArray_Create(void *memoryPoolHandle, void **poly_array)
+{
+    IfNullRet(poly_array, E_POINTER);
+    unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
+
+    try
+    {
+        StaticPolynomialArray *array = new StaticPolynomialArray(*handle);
+        *poly_array = array;
+        return S_OK;
+    }
+    catch (const invalid_argument &)
+    {
+        return E_INVALIDARG;
+    }
+}
+
+SEAL_C_FUNC StaticPolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *context, void *ciphertext, void **poly_array)
+{
+    const SEALContext *ctx = FromVoid<SEALContext>(context);
+    IfNullRet(ctx, E_POINTER);
+
+    const Ciphertext *cipher = FromVoid<Ciphertext>(ciphertext);
+    IfNullRet(cipher, E_POINTER);
+
+    IfNullRet(poly_array, E_POINTER);
+    unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
+
+    try
+    {
+        StaticPolynomialArray *array = new StaticPolynomialArray(*ctx, *cipher, *handle);
+        *poly_array = array;
+        return S_OK;
+    }
+    catch (const invalid_argument &)
+    {
+        return E_INVALIDARG;
+    }
+}
+
+SEAL_C_FUNC StaticPolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array)
+{
+    const SEALContext *ctx = FromVoid<SEALContext>(context);
+    IfNullRet(ctx, E_POINTER);
+
+    const PublicKey *pk = FromVoid<PublicKey>(public_key);
+    IfNullRet(pk, E_POINTER);
+
+    IfNullRet(poly_array, E_POINTER);
+    unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
+
+    try
+    {
+        StaticPolynomialArray *array = new StaticPolynomialArray(*ctx, *pk, *handle);
+        *poly_array = array;
+        return S_OK;
+    }
+    catch (const invalid_argument &)
+    {
+        return E_INVALIDARG;
+    }
+}
+
+SEAL_C_FUNC StaticPolynomialArray_Destroy(void *thisptr)
+{
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+
+    delete poly_array;
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_IsReserved(void *thisptr, bool *is_reserved)
+{
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(is_reserved, E_POINTER);
+
+    *is_reserved = poly_array->is_reserved();
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_IsRns(void *thisptr, bool *is_rns)
+{
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(is_rns, E_POINTER);
+
+    *is_rns = poly_array->is_rns();
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_IsMultiprecision(void *thisptr, bool *is_multiprecision)
+{
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(is_multiprecision, E_POINTER);
+
+    *is_multiprecision = poly_array->is_multiprecision();
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_ToRns(void *thisptr) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+
+    poly_array->to_rns();
+
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_ToMultiprecision(void *thisptr) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+
+    poly_array->to_multiprecision();
+
+    return S_OK;
+
+}
+
+SEAL_C_FUNC StaticPolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_index, uint64_t *data){
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(data, E_POINTER);
+
+    try
+    {
+        *data = *(*poly_array).get_polynomial(poly_index);
+        return S_OK;
+    }
+    catch (const out_of_range &)
+    {
+        return HRESULT_FROM_WIN32(ERROR_INVALID_INDEX);
+    }
+}
+
+SEAL_C_FUNC StaticPolynomialArray_ExportSize(void *thisptr, uint64_t *size) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(size, E_POINTER);
+
+    *size = poly_array->export_size();
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_PerformExport(void *thisptr, uint64_t *data) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(data, E_POINTER);
+
+    poly_array->perform_export(data);
+    return S_OK;
+}
+
+
+SEAL_C_FUNC StaticPolynomialArray_PolySize(void *thisptr, uint64_t *size) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(size, E_POINTER);
+
+    *size = poly_array->poly_size();
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(size, E_POINTER);
+
+    *size = poly_array->poly_modulus_degree();
+    return S_OK;
+}
+
+SEAL_C_FUNC StaticPolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size) {
+    StaticPolynomialArray *poly_array = FromVoid<StaticPolynomialArray>(thisptr);
+    IfNullRet(poly_array, E_POINTER);
+    IfNullRet(size, E_POINTER);
+
+    *size = poly_array->coeff_modulus_size();
+    return S_OK;
+}

--- a/native/src/seal/c/polyarray.h
+++ b/native/src/seal/c/polyarray.h
@@ -3,34 +3,34 @@
 #include "seal/c/defines.h"
 #include <stdint.h>
 
-SEAL_C_FUNC StaticPolynomialArray_Create(void *memoryPoolHandle, void **poly_array);
+SEAL_C_FUNC PolynomialArray_Create(void *memoryPoolHandle, void **poly_array);
 
-SEAL_C_FUNC StaticPolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *context, void *ciphertext, void **poly_array);
+SEAL_C_FUNC PolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *context, void *ciphertext, void **poly_array);
 
-SEAL_C_FUNC StaticPolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array);
+SEAL_C_FUNC PolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array);
 
-SEAL_C_FUNC StaticPolynomialArray_Destroy(void *thisptr);
+SEAL_C_FUNC PolynomialArray_Destroy(void *thisptr);
 
-SEAL_C_FUNC StaticPolynomialArray_IsReserved(void *thisptr, bool *is_reserved);
+SEAL_C_FUNC PolynomialArray_IsReserved(void *thisptr, bool *is_reserved);
 
-SEAL_C_FUNC StaticPolynomialArray_IsRns(void *thisptr, bool *is_rns);
+SEAL_C_FUNC PolynomialArray_IsRns(void *thisptr, bool *is_rns);
 
-SEAL_C_FUNC StaticPolynomialArray_IsMultiprecision(void *thisptr, bool *is_multiprecision);
+SEAL_C_FUNC PolynomialArray_IsMultiprecision(void *thisptr, bool *is_multiprecision);
 
-// SEAL_C_FUNC StaticPolynomialArray_InsertPolynomial(void *thisptr, uint64_t poly_index, uint64_t *array);
+// SEAL_C_FUNC PolynomialArray_InsertPolynomial(void *thisptr, uint64_t poly_index, uint64_t *array);
 
-SEAL_C_FUNC StaticPolynomialArray_ToRns(void *thisptr);
+SEAL_C_FUNC PolynomialArray_ToRns(void *thisptr);
 
-SEAL_C_FUNC StaticPolynomialArray_ToMultiprecision(void *thisptr);
+SEAL_C_FUNC PolynomialArray_ToMultiprecision(void *thisptr);
 
-SEAL_C_FUNC StaticPolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_index, uint64_t *data);
+SEAL_C_FUNC PolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_index, uint64_t *data);
 
-SEAL_C_FUNC StaticPolynomialArray_ExportSize(void *thisptr, uint64_t *size);
+SEAL_C_FUNC PolynomialArray_ExportSize(void *thisptr, uint64_t *size);
 
-SEAL_C_FUNC StaticPolynomialArray_PerformExport(void *thisptr, uint64_t *data);
+SEAL_C_FUNC PolynomialArray_PerformExport(void *thisptr, uint64_t *data);
 
-SEAL_C_FUNC StaticPolynomialArray_PolySize(void *thisptr, uint64_t *size);
+SEAL_C_FUNC PolynomialArray_PolySize(void *thisptr, uint64_t *size);
 
-SEAL_C_FUNC StaticPolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size);
+SEAL_C_FUNC PolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size);
 
-SEAL_C_FUNC StaticPolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size);
+SEAL_C_FUNC PolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size);

--- a/native/src/seal/c/polyarray.h
+++ b/native/src/seal/c/polyarray.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "seal/c/defines.h"
+#include <stdint.h>
+
+SEAL_C_FUNC StaticPolynomialArray_Create(void *memoryPoolHandle, void **poly_array);
+
+SEAL_C_FUNC StaticPolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *context, void *ciphertext, void **poly_array);
+
+SEAL_C_FUNC StaticPolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array);
+
+SEAL_C_FUNC StaticPolynomialArray_Destroy(void *thisptr);
+
+SEAL_C_FUNC StaticPolynomialArray_IsReserved(void *thisptr, bool *is_reserved);
+
+SEAL_C_FUNC StaticPolynomialArray_IsRns(void *thisptr, bool *is_rns);
+
+SEAL_C_FUNC StaticPolynomialArray_IsMultiprecision(void *thisptr, bool *is_multiprecision);
+
+// SEAL_C_FUNC StaticPolynomialArray_InsertPolynomial(void *thisptr, uint64_t poly_index, uint64_t *array);
+
+SEAL_C_FUNC StaticPolynomialArray_ToRns(void *thisptr);
+
+SEAL_C_FUNC StaticPolynomialArray_ToMultiprecision(void *thisptr);
+
+SEAL_C_FUNC StaticPolynomialArray_GetPolynomial(void *thisptr, uint64_t poly_index, uint64_t *data);
+
+SEAL_C_FUNC StaticPolynomialArray_ExportSize(void *thisptr, uint64_t *size);
+
+SEAL_C_FUNC StaticPolynomialArray_PerformExport(void *thisptr, uint64_t *data);
+
+SEAL_C_FUNC StaticPolynomialArray_PolySize(void *thisptr, uint64_t *size);
+
+SEAL_C_FUNC StaticPolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size);
+
+SEAL_C_FUNC StaticPolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size);

--- a/native/src/seal/c/rns.cpp
+++ b/native/src/seal/c/rns.cpp
@@ -1,0 +1,68 @@
+// SEALNet
+#include "seal/c/rns.h"
+#include "seal/c/utilities.h"
+
+// SEAL
+#include "seal/ciphertext.h"
+#include "seal/util/rns.h"
+
+using namespace std;
+using namespace seal;
+using namespace seal::c;
+using namespace seal::util;
+
+SEAL_C_FUNC RNSBase_Create(void *memoryPoolHandle, uint64_t coeffs_length, void **coeffs, void **rnsbase) {
+    IfNullRet(coeffs, E_POINTER);
+    unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
+
+    Modulus **coeff_array = reinterpret_cast<Modulus **>(coeffs);
+    vector<Modulus> coefficients(coeffs_length);
+
+    for (uint64_t i = 0; i < coeffs_length; i++)
+    {
+        coefficients[i] = *coeff_array[i];
+    }
+
+    try
+    {
+        RNSBase *base = new RNSBase(coefficients, *handle);
+        *rnsbase = base;
+        return S_OK;
+    }
+    catch (const invalid_argument &)
+    {
+        return E_INVALIDARG;
+    }
+
+
+}
+
+SEAL_C_FUNC RNSBase_DecomposeArray(void *thisptr, uint64_t *value, uint64_t count, void *memoryPoolHandle) {
+    RNSBase *rnsbase = FromVoid<RNSBase>(thisptr);
+    IfNullRet(rnsbase, E_POINTER);
+
+    IfNullRet(value, E_POINTER);
+    unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
+
+    rnsbase->decompose_array(value, util::safe_cast<size_t>(count), *handle);
+    return S_OK;
+}
+
+SEAL_C_FUNC RNSBase_ComposeArray(void *thisptr, uint64_t *value, uint64_t count, void *memoryPoolHandle) {
+    RNSBase *rnsbase = FromVoid<RNSBase>(thisptr);
+    IfNullRet(rnsbase, E_POINTER);
+
+    IfNullRet(value, E_POINTER);
+    unique_ptr<MemoryPoolHandle> handle = MemHandleFromVoid(memoryPoolHandle);
+
+    rnsbase->compose_array(value, util::safe_cast<size_t>(count), *handle);
+    return S_OK;
+}
+
+SEAL_C_FUNC RNSBase_Destroy(void *thisptr) {
+    RNSBase *rnsbase = FromVoid<RNSBase>(thisptr);
+    IfNullRet(rnsbase, E_POINTER);
+
+    delete rnsbase;
+    return S_OK;
+}

--- a/native/src/seal/c/rns.h
+++ b/native/src/seal/c/rns.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "seal/c/defines.h"
+#include <stdint.h>
+
+SEAL_C_FUNC RNSBase_Create(void *memoryPoolHandle, uint64_t coeff_length, void **coeffs, void **rnsbase);
+
+SEAL_C_FUNC RNSBase_Destroy(void *thisptr);
+
+SEAL_C_FUNC RNSBase_DecomposeArray(void *thisptr, uint64_t *value, uint64_t count, void *memoryPoolHandle);
+
+SEAL_C_FUNC RNSBase_ComposeArray(void *thisptr, uint64_t *value, uint64_t count, void *memoryPoolHandle);

--- a/native/src/seal/decryptor.cpp
+++ b/native/src/seal/decryptor.cpp
@@ -188,8 +188,6 @@ namespace seal
         // Divide scaling variant using BEHZ FullRNS techniques
         context_data.rns_tool()->decrypt_scale_and_round(tmp_dest_modq, destination.data(), pool);
 
-
-
         // How many non-zero coefficients do we really have in the result?
         size_t plain_coeff_count = get_significant_uint64_count_uint(destination.data(), coeff_count);
 

--- a/native/src/seal/dynarray.h
+++ b/native/src/seal/dynarray.h
@@ -312,7 +312,9 @@ namespace seal
         {
             if (index >= size_)
             {
-                throw std::out_of_range("index must be within [0, size)");
+                char buffer[1024];
+                snprintf(buffer, 1024, "index = %lu must be within [0, size = %lu)", index, size_);
+                throw std::out_of_range(buffer);
             }
             return data_[index];
         }
@@ -329,7 +331,9 @@ namespace seal
         {
             if (index >= size_)
             {
-                throw std::out_of_range("index must be within [0, size)");
+                char buffer[1024];
+                snprintf(buffer, 1024, "index = %lu must be within [0, size = %lu)", index, size_);
+                throw std::out_of_range(buffer);
             }
             return data_[index];
         }

--- a/native/src/seal/dynarray.h
+++ b/native/src/seal/dynarray.h
@@ -312,9 +312,7 @@ namespace seal
         {
             if (index >= size_)
             {
-                char buffer[1024];
-                snprintf(buffer, 1024, "index = %lu must be within [0, size = %lu)", index, size_);
-                throw std::out_of_range(buffer);
+                throw std::out_of_range("index must be within [0, size)");
             }
             return data_[index];
         }
@@ -331,9 +329,7 @@ namespace seal
         {
             if (index >= size_)
             {
-                char buffer[1024];
-                snprintf(buffer, 1024, "index = %lu must be within [0, size = %lu)", index, size_);
-                throw std::out_of_range(buffer);
+                throw std::out_of_range("index must be within [0, size)");
             }
             return data_[index];
         }

--- a/native/src/seal/encryptor.cpp
+++ b/native/src/seal/encryptor.cpp
@@ -93,13 +93,26 @@ namespace seal
         PolynomialArray u_destination;
         PolynomialArray e_destination;
 
-        encrypt_zero_internal(parms_id, is_asymmetric, save_seed, false, false, destination, u_destination, e_destination, pool);
+        encrypt_zero_internal(
+            parms_id, 
+            is_asymmetric, 
+            save_seed, 
+            false, 
+            false, 
+            destination, 
+            u_destination, 
+            e_destination, 
+            pool
+        );
     }
 
     void Encryptor::encrypt_zero_internal(
-        parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
+        parms_id_type parms_id, 
+        bool is_asymmetric, 
+        bool save_seed, 
         bool disable_special_modulus,
-        bool export_noise, Ciphertext &destination,
+        bool export_noise, 
+        Ciphertext &destination,
         PolynomialArray &u_destination,
         PolynomialArray &e_destination,
         MemoryPoolHandle pool) const
@@ -150,7 +163,16 @@ namespace seal
 
                 // Zero encryption without modulus switching
                 Ciphertext temp(pool);
-                util::encrypt_zero_asymmetric(public_key_, context_, prev_parms_id, is_ntt_form, false, temp, u_destination, e_destination);
+                util::encrypt_zero_asymmetric(
+                    public_key_, 
+                    context_, 
+                    prev_parms_id, 
+                    is_ntt_form, 
+                    export_noise, 
+                    temp, 
+                    u_destination, 
+                    e_destination
+                );
 
                 // Modulus switching
                 SEAL_ITERATE(iter(temp, destination), temp.size(), [&](auto I) {
@@ -180,7 +202,16 @@ namespace seal
             else
             {
                 // Does not require modulus switching
-                util::encrypt_zero_asymmetric(public_key_, context_, parms_id, is_ntt_form, true, destination, u_destination, e_destination);
+                util::encrypt_zero_asymmetric(
+                    public_key_, 
+                    context_, 
+                    parms_id, 
+                    is_ntt_form, 
+                    export_noise, 
+                    destination, 
+                    u_destination, 
+                    e_destination
+                );
             }
         }
         else
@@ -203,7 +234,6 @@ namespace seal
         PolynomialArray e_destination;
 
         encrypt_internal(plain, is_asymmetric, save_seed, false, false, destination, u_destination, e_destination);
-
     }
 
     void Encryptor::encrypt_internal(

--- a/native/src/seal/encryptor.cpp
+++ b/native/src/seal/encryptor.cpp
@@ -90,8 +90,8 @@ namespace seal
         MemoryPoolHandle pool) const
     {
         // Do not export noise.
-        StaticPolynomialArray u_destination;
-        StaticPolynomialArray e_destination;
+        PolynomialArray u_destination;
+        PolynomialArray e_destination;
 
         encrypt_zero_internal(parms_id, is_asymmetric, save_seed, false, false, destination, u_destination, e_destination, pool);
     }
@@ -100,8 +100,8 @@ namespace seal
         parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
         bool disable_special_modulus,
         bool export_noise, Ciphertext &destination,
-        StaticPolynomialArray &u_destination,
-        StaticPolynomialArray &e_destination,
+        PolynomialArray &u_destination,
+        PolynomialArray &e_destination,
         MemoryPoolHandle pool) const
     {
         // Verify parameters.
@@ -199,8 +199,8 @@ namespace seal
     ) const
     {
         // Do not export noise.
-        StaticPolynomialArray u_destination;
-        StaticPolynomialArray e_destination;
+        PolynomialArray u_destination;
+        PolynomialArray e_destination;
 
         encrypt_internal(plain, is_asymmetric, save_seed, false, false, destination, u_destination, e_destination);
 
@@ -213,8 +213,8 @@ namespace seal
         bool disable_special_modulus,
         bool export_noise,
         Ciphertext &destination,
-        StaticPolynomialArray &u_destination,
-        StaticPolynomialArray &e_destination,
+        PolynomialArray &u_destination,
+        PolynomialArray &e_destination,
         MemoryPoolHandle pool
     ) const
     {

--- a/native/src/seal/encryptor.cpp
+++ b/native/src/seal/encryptor.cpp
@@ -89,6 +89,21 @@ namespace seal
         parms_id_type parms_id, bool is_asymmetric, bool save_seed, Ciphertext &destination,
         MemoryPoolHandle pool) const
     {
+        // Do not export noise.
+        StaticPolynomialArray u_destination;
+        StaticPolynomialArray e_destination;
+
+        encrypt_zero_internal(parms_id, is_asymmetric, save_seed, false, false, destination, u_destination, e_destination, pool);
+    }
+
+    void Encryptor::encrypt_zero_internal(
+        parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
+        bool disable_special_modulus,
+        bool export_noise, Ciphertext &destination,
+        StaticPolynomialArray &u_destination,
+        StaticPolynomialArray &e_destination,
+        MemoryPoolHandle pool) const
+    {
         // Verify parameters.
         if (!pool)
         {
@@ -106,6 +121,7 @@ namespace seal
         size_t coeff_modulus_size = parms.coeff_modulus().size();
         size_t coeff_count = parms.poly_modulus_degree();
         bool is_ntt_form = false;
+        size_t encrypted_size = public_key_.data().size();
 
         if (parms.scheme() == scheme_type::ckks)
         {
@@ -123,7 +139,9 @@ namespace seal
         if (is_asymmetric)
         {
             auto prev_context_data_ptr = context_data.prev_context_data();
-            if (prev_context_data_ptr)
+            auto disable_special = disable_special_modulus && parms.scheme() == scheme_type::bfv;
+
+            if (prev_context_data_ptr && !disable_special)
             {
                 // Requires modulus switching
                 auto &prev_context_data = *prev_context_data_ptr;
@@ -132,7 +150,7 @@ namespace seal
 
                 // Zero encryption without modulus switching
                 Ciphertext temp(pool);
-                util::encrypt_zero_asymmetric(public_key_, context_, prev_parms_id, is_ntt_form, temp);
+                util::encrypt_zero_asymmetric(public_key_, context_, prev_parms_id, is_ntt_form, false, temp, u_destination, e_destination);
 
                 // Modulus switching
                 SEAL_ITERATE(iter(temp, destination), temp.size(), [&](auto I) {
@@ -162,7 +180,7 @@ namespace seal
             else
             {
                 // Does not require modulus switching
-                util::encrypt_zero_asymmetric(public_key_, context_, parms_id, is_ntt_form, destination);
+                util::encrypt_zero_asymmetric(public_key_, context_, parms_id, is_ntt_form, true, destination, u_destination, e_destination);
             }
         }
         else
@@ -173,8 +191,32 @@ namespace seal
     }
 
     void Encryptor::encrypt_internal(
-        const Plaintext &plain, bool is_asymmetric, bool save_seed, Ciphertext &destination,
-        MemoryPoolHandle pool) const
+        const Plaintext &plain, 
+        bool is_asymmetric, 
+        bool save_seed, 
+        Ciphertext &destination,
+        MemoryPoolHandle pool
+    ) const
+    {
+        // Do not export noise.
+        StaticPolynomialArray u_destination;
+        StaticPolynomialArray e_destination;
+
+        encrypt_internal(plain, is_asymmetric, save_seed, false, false, destination, u_destination, e_destination);
+
+    }
+
+    void Encryptor::encrypt_internal(
+        const Plaintext &plain, 
+        bool is_asymmetric, 
+        bool save_seed, 
+        bool disable_special_modulus,
+        bool export_noise,
+        Ciphertext &destination,
+        StaticPolynomialArray &u_destination,
+        StaticPolynomialArray &e_destination,
+        MemoryPoolHandle pool
+    ) const
     {
         // Minimal verification that the keys are set
         if (is_asymmetric)
@@ -206,7 +248,7 @@ namespace seal
                 throw invalid_argument("plain cannot be in NTT form");
             }
 
-            encrypt_zero_internal(context_.first_parms_id(), is_asymmetric, save_seed, destination, pool);
+            encrypt_zero_internal(context_.first_parms_id(), is_asymmetric, save_seed, disable_special_modulus, export_noise, destination, u_destination, e_destination, pool);
 
             // Multiply plain by scalar coeff_div_plaintext and reposition if in upper-half.
             // Result gets added into the c_0 term of ciphertext (c_0,c_1).
@@ -224,7 +266,7 @@ namespace seal
             {
                 throw invalid_argument("plain is not valid for encryption parameters");
             }
-            encrypt_zero_internal(plain.parms_id(), is_asymmetric, save_seed, destination, pool);
+            encrypt_zero_internal(plain.parms_id(), is_asymmetric, save_seed, disable_special_modulus, export_noise, destination, u_destination, e_destination, pool);
 
             auto &parms = context_.get_context_data(plain.parms_id())->parms();
             auto &coeff_modulus = parms.coeff_modulus();
@@ -244,7 +286,7 @@ namespace seal
             {
                 throw invalid_argument("plain cannot be in NTT form");
             }
-            encrypt_zero_internal(context_.first_parms_id(), is_asymmetric, save_seed, destination, pool);
+            encrypt_zero_internal(context_.first_parms_id(), is_asymmetric, save_seed, disable_special_modulus, export_noise, destination, u_destination, e_destination, pool);
             auto context_data_ptr = context_.first_context_data();
             auto &parms = context_data_ptr->parms();
             size_t coeff_count = parms.poly_modulus_degree();

--- a/native/src/seal/encryptor.cpp
+++ b/native/src/seal/encryptor.cpp
@@ -134,7 +134,6 @@ namespace seal
         size_t coeff_modulus_size = parms.coeff_modulus().size();
         size_t coeff_count = parms.poly_modulus_degree();
         bool is_ntt_form = false;
-        size_t encrypted_size = public_key_.data().size();
 
         if (parms.scheme() == scheme_type::ckks)
         {

--- a/native/src/seal/encryptor.h
+++ b/native/src/seal/encryptor.h
@@ -9,10 +9,12 @@
 #include "seal/memorymanager.h"
 #include "seal/plaintext.h"
 #include "seal/publickey.h"
+#include "seal/polyarray.h"
 #include "seal/secretkey.h"
 #include "seal/serializable.h"
 #include "seal/util/defines.h"
 #include "seal/util/ntt.h"
+#include "seal/util/rns.h"
 #include <vector>
 
 namespace seal
@@ -135,6 +137,44 @@ namespace seal
             const Plaintext &plain, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             encrypt_internal(plain, true, false, destination, pool);
+        }
+
+        /**
+        Encrypts a plaintext with the public key and stores the result in
+        destination. In addition, returns the u and e parameters from the
+        encryption.
+
+        The encryption parameters for the resulting ciphertext correspond to:
+        1) in BFV/BGV, the highest (data) level in the modulus switching chain,
+        2) in CKKS, the encryption parameters of the plaintext.
+        Dynamic memory allocations in the process are allocated from the memory
+        pool pointed to by the given MemoryPoolHandle.
+
+        @param[in] plain The plaintext to encrypt
+        @param[in] disable_special_modulus Whether to disable the special modulus.
+        Only applies to BFV.
+        @param[out] destination The ciphertext to overwrite with the encrypted
+        plaintext
+        @param[out] u_destination The polynomial array to write into with the u
+        parameter from BFV. This is required to be un-reserved when passed in.
+        @param[out] e_destination The polynomial array to write into with the e
+        parameter from BFV. This is required to be un-reserved when passed in.
+        @param[in] pool The MemoryPoolHandle pointing to a valid memory pool
+        @throws std::logic_error if a public key is not set
+        @throws std::invalid_argument if plain is not valid for the encryption
+        parameters
+        @throws std::invalid_argument if plain is not in default NTT form
+        @throws std::invalid_argument if pool is uninitialized
+        */
+        inline void encrypt(
+            const Plaintext &plain, 
+            bool disable_special_modulus, 
+            Ciphertext &destination, 
+            StaticPolynomialArray &u_destination, 
+            StaticPolynomialArray &e_destination, 
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
+        {
+            encrypt_internal(plain, true, false, disable_special_modulus, true, destination, u_destination, e_destination, pool);
         }
 
         /**
@@ -416,11 +456,30 @@ namespace seal
         Encryptor &operator=(Encryptor &&assign) = delete;
 
         void encrypt_zero_internal(
-            parms_id_type parms_id, bool is_asymmetric, bool save_seed, Ciphertext &destination,
+            parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
+            Ciphertext &destination,
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
+
+        void encrypt_zero_internal(
+            parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
+            bool disable_special_modulus,
+            bool export_noise, Ciphertext &destination,
+            StaticPolynomialArray &u_destination,
+            StaticPolynomialArray &e_destination,
             MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         void encrypt_internal(
-            const Plaintext &plain, bool is_asymmetric, bool save_seed, Ciphertext &destination,
+            const Plaintext &plain, bool is_asymmetric, bool save_seed, 
+            Ciphertext &destination, 
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
+
+        void encrypt_internal(
+            const Plaintext &plain, bool is_asymmetric, bool save_seed, 
+            bool disable_special_modulus,
+            bool export_noise, 
+            Ciphertext &destination,
+            StaticPolynomialArray &u_destination,
+            StaticPolynomialArray &e_destination,
             MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         SEALContext context_;

--- a/native/src/seal/encryptor.h
+++ b/native/src/seal/encryptor.h
@@ -170,8 +170,8 @@ namespace seal
             const Plaintext &plain, 
             bool disable_special_modulus, 
             Ciphertext &destination, 
-            StaticPolynomialArray &u_destination, 
-            StaticPolynomialArray &e_destination, 
+            PolynomialArray &u_destination, 
+            PolynomialArray &e_destination, 
             MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             encrypt_internal(plain, true, false, disable_special_modulus, true, destination, u_destination, e_destination, pool);
@@ -464,8 +464,8 @@ namespace seal
             parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
             bool disable_special_modulus,
             bool export_noise, Ciphertext &destination,
-            StaticPolynomialArray &u_destination,
-            StaticPolynomialArray &e_destination,
+            PolynomialArray &u_destination,
+            PolynomialArray &e_destination,
             MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         void encrypt_internal(
@@ -478,8 +478,8 @@ namespace seal
             bool disable_special_modulus,
             bool export_noise, 
             Ciphertext &destination,
-            StaticPolynomialArray &u_destination,
-            StaticPolynomialArray &e_destination,
+            PolynomialArray &u_destination,
+            PolynomialArray &e_destination,
             MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         SEALContext context_;

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -7,11 +7,11 @@ using namespace seal::util;
 
 namespace seal
 {
-    StaticPolynomialArray::StaticPolynomialArray(
+    PolynomialArray::PolynomialArray(
         const SEALContext &context,
         const Ciphertext &ciphertext,
         MemoryPoolHandle pool
-    ) : StaticPolynomialArray(pool) {
+    ) : PolynomialArray(pool) {
 
         auto &parms = context.first_context_data()->parms();
         auto &coeff_modulus = parms.coeff_modulus();
@@ -29,11 +29,11 @@ namespace seal
         }
     }
 
-    StaticPolynomialArray::StaticPolynomialArray(
+    PolynomialArray::PolynomialArray(
         const SEALContext &context,
         const PublicKey &public_key,
         MemoryPoolHandle pool
-    ) : StaticPolynomialArray(pool) {
+    ) : PolynomialArray(pool) {
 
         auto &ciphertext = public_key.data();
         auto &parms = context.first_context_data()->parms();
@@ -53,13 +53,13 @@ namespace seal
     }
 
 
-    void StaticPolynomialArray::reserve(
+    void PolynomialArray::reserve(
         std::size_t poly_size,
         std::size_t coeff_size,
         const std::vector<Modulus> &rnsbase
     ) {
         if (reserved_) {
-            throw std::logic_error("StaticPolynomialArray can only be reserved once.");
+            throw std::logic_error("PolynomialArray can only be reserved once.");
         }
 
         set_modulus(rnsbase);
@@ -74,7 +74,7 @@ namespace seal
         reserved_ = true;
     }
 
-    void StaticPolynomialArray::to_multiprecision() {
+    void PolynomialArray::to_multiprecision() {
         // If we are already in multiprecision form then we don't need to convert back.
         if (!is_rns_) {
             return;
@@ -91,7 +91,7 @@ namespace seal
     /**
     Modifies the polynomial array in place to RNS form.
     */
-    void StaticPolynomialArray::to_rns() {
+    void PolynomialArray::to_rns() {
         // If we are already in RNS form then we don't need to convert back.
         if (is_rns_) {
             return;

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -71,6 +71,7 @@ namespace seal
 
         data_ = allocate<std::uint64_t>(len_, pool_);
 
+        polynomial_reserved_.resize(poly_size_, false);
         reserved_ = true;
     }
 

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#include "seal/polyarray.h"
+
+using namespace seal::util;
+
+namespace seal
+{
+    StaticPolynomialArray::StaticPolynomialArray(
+        const SEALContext &context,
+        const Ciphertext &ciphertext,
+        MemoryPoolHandle pool
+    ) : StaticPolynomialArray(pool) {
+
+        auto &parms = context.first_context_data()->parms();
+        auto &coeff_modulus = parms.coeff_modulus();
+        auto coeff_modulus_size = ciphertext.coeff_modulus_size();
+        auto poly_modulus_degree = ciphertext.poly_modulus_degree();
+        auto num_poly = ciphertext.size();
+
+        reserve(num_poly, poly_modulus_degree, coeff_modulus);
+
+        // The ciphertexts are stored in the same RNS format as the
+        // other polynomial arrays.
+        for (int i = 0; i < num_poly; i++) {
+            const auto data_ptr = ciphertext.data() + i * (poly_modulus_degree * coeff_modulus_size);
+            insert_polynomial(i, data_ptr);
+        }
+    }
+
+    StaticPolynomialArray::StaticPolynomialArray(
+        const SEALContext &context,
+        const PublicKey &public_key,
+        MemoryPoolHandle pool
+    ) : StaticPolynomialArray(pool) {
+
+        auto &ciphertext = public_key.data();
+        auto &parms = context.first_context_data()->parms();
+        auto &coeff_modulus = parms.coeff_modulus();
+        auto coeff_modulus_size = ciphertext.coeff_modulus_size();
+        auto poly_modulus_degree = ciphertext.poly_modulus_degree();
+        auto num_poly = ciphertext.size();
+
+        reserve(num_poly, poly_modulus_degree, coeff_modulus);
+
+        // The ciphertexts are stored in the same RNS format as the
+        // other polynomial arrays.
+        for (int i = 0; i < num_poly; i++) {
+            const auto data_ptr = ciphertext.data() + i * (poly_modulus_degree * coeff_modulus_size);
+            insert_polynomial(i, data_ptr);
+        }
+    }
+
+
+    void StaticPolynomialArray::reserve(
+        std::size_t poly_size,
+        std::size_t coeff_size,
+        const std::vector<Modulus> &rnsbase
+    ) {
+        if (reserved_) {
+            throw std::logic_error("StaticPolynomialArray can only be reserved once.");
+        }
+
+        set_modulus(rnsbase);
+
+        poly_size_ = poly_size;
+        coeff_size_ = coeff_size;
+        poly_len_ = coeff_size * coeff_modulus_size_;
+        len_ = poly_size_ * poly_len_;
+
+        data_ = allocate<std::uint64_t>(len_, pool_);
+
+        reserved_ = true;
+    }
+
+    void StaticPolynomialArray::to_multiprecision() {
+        // If we are already in multiprecision form then we don't need to convert back.
+        if (!is_rns_) {
+            return;
+        }
+
+        for (int i = 0; i < poly_size_; i++) {
+            auto poly_start = get_polynomial(i);
+            rnsbase_->compose_array(poly_start, coeff_size_, pool_);
+        }
+
+        is_rns_ = false;
+    }
+
+    /**
+    Modifies the polynomial array in place to RNS form.
+    */
+    void StaticPolynomialArray::to_rns() {
+        // If we are already in RNS form then we don't need to convert back.
+        if (is_rns_) {
+            return;
+        }
+
+        for (int i = 0; i < poly_size_; i++) {
+            auto poly_start = get_polynomial(i);
+            rnsbase_->decompose_array(poly_start, coeff_size_, pool_);
+        }
+
+        is_rns_ = true;
+    }
+}

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -17,35 +17,35 @@ namespace seal
         associated with the array so that it can be used to convert back and
         forth between RNS and multiprecision form.
         */
-        class StaticPolynomialArray
+        class PolynomialArray
         {
             public:
                 /**
-                Creates an uninitialized StaticPolynomialArray instance from a
+                Creates an uninitialized PolynomialArray instance from a
                 given pool. This is created so that a reference can be passed
                 into a function and whatever polynomial array of interest can be
                 converted into functions that return a polynomial array.
                 */
-                StaticPolynomialArray(MemoryPoolHandle pool = MemoryManager::GetPool()):
+                PolynomialArray(MemoryPoolHandle pool = MemoryManager::GetPool()):
                 pool_(std::move(pool))
                 {}
 
                 /**
-                Create a StaticPolynomialArray from a ciphertext.
+                Create a PolynomialArray from a ciphertext.
                 */
-                StaticPolynomialArray(
+                PolynomialArray(
                     const SEALContext &context, const Ciphertext &ciphertext, MemoryPoolHandle pool
                 );
 
                 /**
-                Create a StaticPolynomialArray from a public key. Note that the
+                Create a PolynomialArray from a public key. Note that the
                 special modulus is dropped from this representation.
                 */
-                StaticPolynomialArray(
+                PolynomialArray(
                     const SEALContext &context, const PublicKey &public_key, MemoryPoolHandle pool
                 );
 
-                ~StaticPolynomialArray()
+                ~PolynomialArray()
                 {
                     if (zero_on_destruction_) {
                         util::set_zero_uint(len_, data_.get());
@@ -193,7 +193,7 @@ namespace seal
             private:
                 // We make an independent function instead of setting on
                 // initialization so that we can allocate a
-                // StaticPolynomialArray without knowing the modulus yet (it
+                // PolynomialArray without knowing the modulus yet (it
                 // gets passed in later)
                 void set_modulus(const std::vector<Modulus> &coeff_modulus){
                     coeff_modulus_size_ = coeff_modulus.size();

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -101,8 +101,17 @@ namespace seal
                 Insert a polynomial into the data array of the
                 */
                 void insert_polynomial(std::size_t poly_index, const uint64_t* array) {
+
+                    // This performs a check that the polynomial is in bounds.
                     auto poly_start = get_polynomial(poly_index);
+
+                    if (polynomial_reserved_[poly_index]) {
+                        throw std::logic_error("Attempted to overwrite a polynomial in PolynomialArray.");
+                    }
+
                     util::set_uint(array, poly_len_, poly_start);
+
+                    polynomial_reserved_[poly_index] = true;
                 }
 
                 /**
@@ -139,7 +148,7 @@ namespace seal
                 SEAL_NODISCARD inline std::uint64_t* get_polynomial(std::size_t poly_index) 
                 {
                     if (poly_index >= poly_size_) {
-                        throw std::logic_error("Polynomial outside of RNS array count");
+                        throw std::logic_error("Polynomial index greater than number of polynomials stored");
                     }
    
                     auto poly_start = data_.get() + poly_len_ * poly_index;
@@ -217,7 +226,10 @@ namespace seal
                 std::size_t coeff_modulus_size_ = 0;
                 std::size_t poly_len_ = 0;
                 std::size_t len_ = 0;
+
                 bool reserved_ = false;
+                std::vector<bool> polynomial_reserved_;
+
                 bool zero_on_destruction_ = true;
 
                 // Is this array in RNS form or in multiprecision form?

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -45,6 +45,25 @@ namespace seal
                     const SEALContext &context, const PublicKey &public_key, MemoryPoolHandle pool
                 );
 
+                ~StaticPolynomialArray()
+                {
+                    if (zero_on_destruction_) {
+                        util::set_zero_uint(len_, data_.get());
+
+                        // We also reset all the elements in the class to make
+                        // the bits associated with a deallocated object look
+                        // the same as a new object that is unreserved.
+                        poly_size_ = 0;
+                        coeff_size_ = 0;
+                        coeff_modulus_size_ = 0;
+                        poly_len_ = 0;
+                        len_ = 0;
+                        reserved_ = false;
+                        zero_on_destruction_ = true;
+                        is_rns_ = true;
+                    }
+                }
+
                 /**
                 Reserve space for a specfic polynomial. This can only be called
                 once; further calls with throw a logic error indicating that the
@@ -199,6 +218,7 @@ namespace seal
                 std::size_t poly_len_ = 0;
                 std::size_t len_ = 0;
                 bool reserved_ = false;
+                bool zero_on_destruction_ = true;
 
                 // Is this array in RNS form or in multiprecision form?
                 bool is_rns_ = true;

--- a/native/src/seal/util/rlwe.cpp
+++ b/native/src/seal/util/rlwe.cpp
@@ -193,8 +193,8 @@ namespace seal
             const PublicKey &public_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
             bool export_noise,
             Ciphertext &destination, 
-            StaticPolynomialArray &u_destination,
-            StaticPolynomialArray &e_destination
+            PolynomialArray &u_destination,
+            PolynomialArray &e_destination
         ) {
 #ifdef SEAL_DEBUG
             if (!is_valid_for(public_key, context))

--- a/native/src/seal/util/rlwe.cpp
+++ b/native/src/seal/util/rlwe.cpp
@@ -190,7 +190,10 @@ namespace seal
         }
 
         void encrypt_zero_asymmetric(
-            const PublicKey &public_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
+            const PublicKey &public_key, 
+            const SEALContext &context, 
+            parms_id_type parms_id, 
+            bool is_ntt_form,
             bool export_noise,
             Ciphertext &destination, 
             PolynomialArray &u_destination,

--- a/native/src/seal/util/rlwe.cpp
+++ b/native/src/seal/util/rlwe.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "seal/ciphertext.h"
+#include "seal/polyarray.h"
 #include "seal/randomgen.h"
 #include "seal/randomtostd.h"
 #include "seal/util/clipnormal.h"
@@ -31,6 +32,7 @@ namespace seal
             SEAL_ITERATE(iter(destination), coeff_count, [&](auto &I) {
                 uint64_t rand = dist(engine);
                 uint64_t flag = static_cast<uint64_t>(-static_cast<int64_t>(rand == 0));
+
                 SEAL_ITERATE(
                     iter(StrideIter<uint64_t *>(&I, coeff_count), coeff_modulus), coeff_modulus_size,
                     [&](auto J) { *get<0>(J) = rand + (flag & get<1>(J).value()) - 1; });
@@ -94,6 +96,7 @@ namespace seal
             SEAL_ITERATE(iter(destination), coeff_count, [&](auto &I) {
                 int32_t noise = cbd();
                 uint64_t flag = static_cast<uint64_t>(-static_cast<int64_t>(noise < 0));
+
                 SEAL_ITERATE(
                     iter(StrideIter<uint64_t *>(&I, coeff_count), coeff_modulus), coeff_modulus_size,
                     [&](auto J) { *get<0>(J) = static_cast<uint64_t>(noise) + (flag & get<1>(J).value()); });
@@ -186,10 +189,39 @@ namespace seal
             }
         }
 
+
+        // Convert RNS form back to positional. This assumes that the positional
+        // value was less than all of the moduli to start, and hence we can
+        // convert using only one residual. This also means the results can be
+        // stored in a machine integer.
+        // Not needed, as RNSBase::compose will return the result. The advantage
+        // of this method is that it is likely faster and also converts to
+        // negative numbers.
+        void convert_small_to_positional(CoeffIter data, vector<int64_t>& output, uint64_t coeff_count, const vector<Modulus>& coeff_modulus) {
+            output.resize(coeff_count);
+
+            auto first_coeff_mod = coeff_modulus[0].value();
+            auto first_coeff_mod_half = first_coeff_mod / 2;
+
+            for (int i = 0; i < coeff_count; i++) {
+                // The first residual for each element in the polynomial/array.
+                auto first_residual_i = data[i];
+
+                if (first_residual_i > first_coeff_mod_half) {
+                    output[i] = first_residual_i - first_coeff_mod;
+                } else {
+                    output[i] = first_residual_i;
+                }
+            }
+        }
+
         void encrypt_zero_asymmetric(
             const PublicKey &public_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
-            Ciphertext &destination)
-        {
+            bool export_noise,
+            Ciphertext &destination, 
+            StaticPolynomialArray &u_destination,
+            StaticPolynomialArray &e_destination
+        ) {
 #ifdef SEAL_DEBUG
             if (!is_valid_for(public_key, context))
             {
@@ -223,12 +255,27 @@ namespace seal
             auto prng = parms.random_generator()->create();
 
             // Generate u <-- R_3
+            auto len = coeff_count * coeff_modulus_size;
+
             auto u(allocate_poly(coeff_count, coeff_modulus_size, pool));
             sample_poly_ternary(prng, parms, u.get());
+
+            if (export_noise) {
+                u_destination.reserve(1, coeff_count, coeff_modulus);
+                u_destination.insert_polynomial(0, u.get());
+            }
+
+            auto u_copy(allocate_uint(len, pool));
+            set_uint(u.get(), len, u_copy.get());
+
+            auto rns = RNSBase(coeff_modulus, pool);
+
+            rns.compose_array(u_copy.get(), coeff_count, pool);
 
             // c[j] = u * public_key[j]
             for (size_t i = 0; i < coeff_modulus_size; i++)
             {
+                // Offset into array for modulus m_i
                 ntt_negacyclic_harvey(u.get() + i * coeff_count, ntt_tables[i]);
                 for (size_t j = 0; j < encrypted_size; j++)
                 {
@@ -244,12 +291,21 @@ namespace seal
                 }
             }
 
+            if (export_noise) {
+                e_destination.reserve(encrypted_size, coeff_count, coeff_modulus);
+            }
+
             // Generate e_j <-- chi
             // c[j] = public_key[j] * u + e[j] in BFV/CKKS, = public_key[j] * u + p * e[j] in BGV,
             for (size_t j = 0; j < encrypted_size; j++)
             {
+                // u is being modified in place to add some error terms.
                 SEAL_NOISE_SAMPLER(prng, parms, u.get());
                 RNSIter gaussian_iter(u.get(), coeff_count);
+
+                if (export_noise) {
+                    e_destination.insert_polynomial(j, u.get());
+                }
 
                 // In BGV, p * e is used
                 if (type == scheme_type::bgv)

--- a/native/src/seal/util/rlwe.h
+++ b/native/src/seal/util/rlwe.h
@@ -6,6 +6,7 @@
 #include "seal/ciphertext.h"
 #include "seal/context.h"
 #include "seal/encryptionparams.h"
+#include "seal/polyarray.h"
 #include "seal/publickey.h"
 #include "seal/randomgen.h"
 #include "seal/secretkey.h"
@@ -90,11 +91,18 @@ namespace seal
         @param[in] context The SEALContext containing a chain of ContextData
         @param[in] parms_id Indicates the level of encryption
         @param[in] is_ntt_form If true, store ciphertext in NTT form
+        @param[in] export_noise Whether to export the ciphertext noise inputs (u, e_i)
         @param[out] destination The output ciphertext - an encryption of zero
+        @param[out] u The u noise value.
+        @param[out] e The u noise value.
         */
         void encrypt_zero_asymmetric(
             const PublicKey &public_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
-            Ciphertext &destination);
+            bool export_noise,
+            Ciphertext &destination,
+            StaticPolynomialArray &u_destination,
+            StaticPolynomialArray &e_destination
+        );
 
         /**
         Create an encryption of zero with a secret key and store in a ciphertext.

--- a/native/src/seal/util/rlwe.h
+++ b/native/src/seal/util/rlwe.h
@@ -100,8 +100,8 @@ namespace seal
             const PublicKey &public_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
             bool export_noise,
             Ciphertext &destination,
-            StaticPolynomialArray &u_destination,
-            StaticPolynomialArray &e_destination
+            PolynomialArray &u_destination,
+            PolynomialArray &e_destination
         );
 
         /**

--- a/native/src/seal/util/rns.h
+++ b/native/src/seal/util/rns.h
@@ -5,6 +5,7 @@
 
 #include "seal/memorymanager.h"
 #include "seal/modulus.h"
+#include "seal/util/common.h"
 #include "seal/util/iterator.h"
 #include "seal/util/ntt.h"
 #include "seal/util/pointer.h"


### PR DESCRIPTION
Does a few pieces to enable performing proofs on ciphertexts:

1. Disables the special modulus with the `disable_special_modulus` parameter to the disable the modulus switching in BFV using the special modulus. This is so that the form of the ciphertexts matches the definition of textbook BFV in a way that it can be shown that the encryption equations hold directly. This is exposed through the longer `Encryptor::encrypt_internal`.
2. The `u` and `e` parameters can be acquired when encrypting a value; this is also required for the later ciphertext correctly constructed proofs.
3. A `StaticPolynomialArray` class is introduced to hold onto polynomial data and easy convert it to and from RNS/BigInt form. The data tied to these arrays is stored on the global memory pool by default. Their size can only be set once; they are meant to store data but not dynamically change size. This can be seen as an array with only one set size (when set), as opposed to the `DynArray` backing other classes like `Ciphertext`.
4. `RNSBase` has been exported through the C interface should it be needed. Currently it is not planned to use this directly in the sunscreen compiler as the `StaticPolynomialArray` class can perform the conversions to and from RNS. However, `RNSBase` has more functionality such as switching modulus bases.

While the outputs seem to be correct, we have not yet performed the full or zero knowledge proof of a correctly constructed ciphertext; more edits may come to disable the special modulus.

Additionally, defining a modulus is now a tad awkward: a modulus array with 5 primes will only use the first four for the public key and for encryption, while the special prime/modulus (the last one in the list) will be ignored. This currently allows the most minimal modifications to SEAL itself. We could potentially investigate deeper and modify more of SEAL to remove the extraneous modulus in the case of the disable special modulus, but this could be quite invasive and may require re-evaluation to determine if the security is equivalent.

I'm making a PR for these changes now while working on the Rust component in the sunscreen compiler.

At some point we should add a compile and test CI. In the meantime you'll have to trust this is real:

```
[----------] Global test environment tear-down
[==========] 280 tests from 42 test suites ran. (1395 ms total)
[  PASSED  ] 280 tests.
```