### PR TITLE
Add copy constructor for PolynomialArray

### DIFF
--- a/native/src/seal/c/polyarray.cpp
+++ b/native/src/seal/c/polyarray.cpp
@@ -85,7 +85,6 @@ SEAL_C_FUNC PolynomialArray_Copy(void *copy, void **poly_array) {
     PolynomialArray *pa = new PolynomialArray(*copyptr);
     *poly_array = pa;
     return S_OK;
-
 }
 
 SEAL_C_FUNC PolynomialArray_Destroy(void *thisptr)

--- a/native/src/seal/c/polyarray.cpp
+++ b/native/src/seal/c/polyarray.cpp
@@ -77,6 +77,17 @@ SEAL_C_FUNC PolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *co
     }
 }
 
+SEAL_C_FUNC PolynomialArray_Copy(void *copy, void **poly_array) {
+    PolynomialArray *copyptr = FromVoid<PolynomialArray>(copy);
+    IfNullRet(copyptr, E_POINTER);
+    IfNullRet(poly_array, E_POINTER);
+
+    PolynomialArray *pa = new PolynomialArray(*copyptr);
+    *poly_array = pa;
+    return S_OK;
+
+}
+
 SEAL_C_FUNC PolynomialArray_Destroy(void *thisptr)
 {
     PolynomialArray *poly_array = FromVoid<PolynomialArray>(thisptr);

--- a/native/src/seal/c/polyarray.h
+++ b/native/src/seal/c/polyarray.h
@@ -9,6 +9,8 @@ SEAL_C_FUNC PolynomialArray_CreateFromCiphertext(void *memoryPoolHandle, void *c
 
 SEAL_C_FUNC PolynomialArray_CreateFromPublicKey(void *memoryPoolHandle, void *context, void *public_key, void **poly_array);
 
+SEAL_C_FUNC PolynomialArray_Copy(void *copy, void **poly_array);
+
 SEAL_C_FUNC PolynomialArray_Destroy(void *thisptr);
 
 SEAL_C_FUNC PolynomialArray_IsReserved(void *thisptr, bool *is_reserved);

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -52,6 +52,29 @@ namespace seal
         }
     }
 
+    PolynomialArray &PolynomialArray::operator=(const PolynomialArray &assign)
+    {
+        // Check for self-assignment
+        if (this == &assign)
+        {
+            return *this;
+        }
+
+        auto poly_size = assign.poly_size();
+        auto coeff_modulus_size = assign.coeff_modulus_size();
+        auto coeff_modulus = assign.coeff_modulus_;
+        auto poly_modulus_degree = assign.poly_modulus_degree();
+
+        // Then reserve
+        reserve(poly_size, poly_modulus_degree, coeff_modulus);
+
+        for (std::size_t i = 0; i < poly_size; i++) {
+            const auto data_ptr = assign.get_polynomial(i);
+            insert_polynomial(i, data_ptr);
+        }
+
+        return *this;
+    }
 
     void PolynomialArray::reserve(
         std::size_t poly_size,

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -52,6 +52,25 @@ namespace seal
         }
     }
 
+    PolynomialArray::PolynomialArray(const PolynomialArray &copy): PolynomialArray(copy.pool_) {
+        // These parameters in the result object are internally stored once
+        // reserve is called.
+        auto poly_size = copy.poly_size();
+        auto coeff_modulus_size = copy.coeff_modulus_size();
+        auto coeff_modulus = copy.coeff_modulus_;
+        auto poly_modulus_degree = copy.poly_modulus_degree();
+
+        // Then reserve
+        reserve(poly_size, poly_modulus_degree, coeff_modulus);
+
+        for (std::size_t i = 0; i < poly_size; i++) {
+            if (copy.polynomial_reserved_[i]) {
+                const auto data_ptr = copy.get_polynomial(i);
+                insert_polynomial(i, data_ptr);
+            }
+        }
+    }
+
     PolynomialArray &PolynomialArray::operator=(const PolynomialArray &assign)
     {
         // Check for self-assignment
@@ -60,6 +79,8 @@ namespace seal
             return *this;
         }
 
+        // These parameters in the result object are internally stored once
+        // reserve is called.
         auto poly_size = assign.poly_size();
         auto coeff_modulus_size = assign.coeff_modulus_size();
         auto coeff_modulus = assign.coeff_modulus_;
@@ -69,8 +90,10 @@ namespace seal
         reserve(poly_size, poly_modulus_degree, coeff_modulus);
 
         for (std::size_t i = 0; i < poly_size; i++) {
-            const auto data_ptr = assign.get_polynomial(i);
-            insert_polynomial(i, data_ptr);
+            if (assign.polynomial_reserved_[i]) {
+                const auto data_ptr = assign.get_polynomial(i);
+                insert_polynomial(i, data_ptr);
+            }
         }
 
         return *this;

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -71,34 +71,6 @@ namespace seal
         }
     }
 
-    PolynomialArray &PolynomialArray::operator=(const PolynomialArray &assign)
-    {
-        // Check for self-assignment
-        if (this == &assign)
-        {
-            return *this;
-        }
-
-        // These parameters in the result object are internally stored once
-        // reserve is called.
-        auto poly_size = assign.poly_size();
-        auto coeff_modulus_size = assign.coeff_modulus_size();
-        auto coeff_modulus = assign.coeff_modulus_;
-        auto poly_modulus_degree = assign.poly_modulus_degree();
-
-        // Then reserve
-        reserve(poly_size, poly_modulus_degree, coeff_modulus);
-
-        for (std::size_t i = 0; i < poly_size; i++) {
-            if (assign.polynomial_reserved_[i]) {
-                const auto data_ptr = assign.get_polynomial(i);
-                insert_polynomial(i, data_ptr);
-            }
-        }
-
-        return *this;
-    }
-
     void PolynomialArray::reserve(
         std::size_t poly_size,
         std::size_t coeff_size,

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -59,18 +59,6 @@ namespace seal
                 */
                 PolynomialArray(PolynomialArray &&source) = default;
 
-                /**
-                Creates a new ciphertext by copying a given one.
-
-                @param[in] copy The ciphertext to copy from
-                @param[in] pool The MemoryPoolHandle pointing to a valid memory pool
-                @throws std::invalid_argument if pool is uninitialized
-                */
-                PolynomialArray(const PolynomialArray &copy, MemoryPoolHandle pool) : PolynomialArray(std::move(pool))
-                {
-                    *this = copy;
-                }
-
                 ~PolynomialArray()
                 {
                     if (zero_on_destruction_) {

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -45,6 +45,25 @@ namespace seal
                     const SEALContext &context, const PublicKey &public_key, MemoryPoolHandle pool
                 );
 
+                /**
+                Creates a new ciphertext by moving a given one.
+
+                @param[in] source The ciphertext to move from
+                */
+                PolynomialArray(PolynomialArray &&source) = default;
+
+                /**
+                Creates a new ciphertext by copying a given one.
+
+                @param[in] copy The ciphertext to copy from
+                @param[in] pool The MemoryPoolHandle pointing to a valid memory pool
+                @throws std::invalid_argument if pool is uninitialized
+                */
+                PolynomialArray(const PolynomialArray &copy, MemoryPoolHandle pool = MemoryManager::GetPool()) : PolynomialArray(std::move(pool))
+                {
+                    *this = copy;
+                }
+
                 ~PolynomialArray()
                 {
                     if (zero_on_destruction_) {
@@ -63,6 +82,13 @@ namespace seal
                         is_rns_ = true;
                     }
                 }
+
+                /**
+                Copies a given ciphertext to the current one.
+
+                @param[in] assign The ciphertext to copy from
+                */
+                PolynomialArray &operator=(const PolynomialArray &assign);
 
                 /**
                 Reserve space for a specfic polynomial. This can only be called
@@ -145,7 +171,7 @@ namespace seal
                 polynomial array. Throws a logic error if the index is larger
                 than the number of polynomials held by the polynomial array.
                 */
-                SEAL_NODISCARD inline std::uint64_t* get_polynomial(std::size_t poly_index) 
+                SEAL_NODISCARD inline std::uint64_t *get_polynomial(std::size_t poly_index) 
                 {
                     if (poly_index >= poly_size_) {
                         throw std::logic_error("Polynomial index greater than number of polynomials stored");
@@ -153,6 +179,16 @@ namespace seal
    
                     auto poly_start = data_.get() + poly_len_ * poly_index;
                     return poly_start;
+                }
+
+                /**
+                Get a pointer to the start of a specific polynomial in the
+                polynomial array. Throws a logic error if the index is larger
+                than the number of polynomials held by the polynomial array.
+                */
+                SEAL_NODISCARD inline const std::uint64_t *get_polynomial(std::size_t poly_index) const  
+                {
+                    return get_polynomial(poly_index);
                 }
 
                 /**
@@ -205,20 +241,15 @@ namespace seal
                 // PolynomialArray without knowing the modulus yet (it
                 // gets passed in later)
                 void set_modulus(const std::vector<Modulus> &coeff_modulus){
+                    coeff_modulus_ = coeff_modulus;
                     coeff_modulus_size_ = coeff_modulus.size();
-
-                    // Other classes do a check that the modulus set is correct;
-                    // the assumption here is that we are creating an instance
-                    // of this class from an existing (verified) modulus set.
-                    coeff_modulus_ = allocate<Modulus>(coeff_modulus_size_, pool_);
-                    copy_n(coeff_modulus.cbegin(), coeff_modulus_size_, coeff_modulus_.get());
 
                     rnsbase_ = allocate<RNSBase>(pool_, coeff_modulus, pool_);
                 }
 
                 MemoryPoolHandle pool_;
                 Pointer<uint64_t> data_;
-                Pointer<Modulus> coeff_modulus_;
+                std::vector<Modulus> coeff_modulus_;
                 Pointer<RNSBase> rnsbase_;
 
                 std::size_t poly_size_ = 0;

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -46,6 +46,13 @@ namespace seal
                 );
 
                 /**
+                Creates a new ciphertext by copying a given one.
+
+                @param[in] source The ciphertext to move from
+                */
+                PolynomialArray(const PolynomialArray &copy);
+
+                /**
                 Creates a new ciphertext by moving a given one.
 
                 @param[in] source The ciphertext to move from
@@ -59,7 +66,7 @@ namespace seal
                 @param[in] pool The MemoryPoolHandle pointing to a valid memory pool
                 @throws std::invalid_argument if pool is uninitialized
                 */
-                PolynomialArray(const PolynomialArray &copy, MemoryPoolHandle pool = MemoryManager::GetPool()) : PolynomialArray(std::move(pool))
+                PolynomialArray(const PolynomialArray &copy, MemoryPoolHandle pool) : PolynomialArray(std::move(pool))
                 {
                     *this = copy;
                 }

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -188,7 +188,12 @@ namespace seal
                 */
                 SEAL_NODISCARD inline const std::uint64_t *get_polynomial(std::size_t poly_index) const  
                 {
-                    return get_polynomial(poly_index);
+                    if (poly_index >= poly_size_) {
+                        throw std::logic_error("Polynomial index greater than number of polynomials stored");
+                    }
+   
+                    auto poly_start = data_.get() + poly_len_ * poly_index;
+                    return poly_start;
                 }
 
                 /**


### PR DESCRIPTION
Create a copy constructor for `PolynomialArray`, and convert the modulus stored inside to a vector instead of allocated in the memory pool.

This does not quite follow the ciphertext semantics because a pool is required (with a default value of the global pool). Otherwise I got a "explicitly defaulted copy constructor is implicitly deleted" error when attempting to define a copy constructor for `PolynomialArray`.

This is so we can clone in the rust wrapper.