### PR TITLE
Encrypt functions take in seed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Install clang and other utilities
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential clang
+
     - name: Build SEAL
       run: |
         cmake -S . -B build -DSEAL_BUILD_EXAMPLES=ON -DSEAL_BUILD_TESTS=ON -DSEAL_THROW_ON_TRANSPARENT_CIPHERTEXT=ON -DSEAL_BUILD_SEAL_C=ON

--- a/native/src/seal/c/encryptor.h
+++ b/native/src/seal/c/encryptor.h
@@ -24,6 +24,9 @@ SEAL_C_FUNC Encryptor_Encrypt(void *thisptr, void *plaintext, void *destination,
 SEAL_C_FUNC Encryptor_EncryptReturnComponents(
     void *thisptr, void *plaintext, bool disable_special_modulus, void *destination, void *u_destination, void *e_destination, void *pool_handle);
 
+SEAL_C_FUNC Encryptor_EncryptReturnComponentsSetSeed(
+    void *thisptr, void *plaintext, bool disable_special_modulus, void *destination, void *u_destination, void *e_destination, void *seed, void *pool_handle);
+
 SEAL_C_FUNC Encryptor_EncryptZero1(void *thisptr, uint64_t *parms_id, void *destination, void *pool_handle);
 
 SEAL_C_FUNC Encryptor_EncryptZero2(void *thisptr, void *destination, void *pool_handle);

--- a/native/src/seal/encryptor.h
+++ b/native/src/seal/encryptor.h
@@ -16,6 +16,7 @@
 #include "seal/util/ntt.h"
 #include "seal/util/rns.h"
 #include <vector>
+#include <optional>
 
 namespace seal
 {
@@ -172,9 +173,10 @@ namespace seal
             Ciphertext &destination, 
             PolynomialArray &u_destination, 
             PolynomialArray &e_destination, 
+            std::optional<prng_seed_type> seed = std::nullopt,
             MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
-            encrypt_internal(plain, true, false, disable_special_modulus, true, destination, u_destination, e_destination, pool);
+            encrypt_internal(plain, true, false, disable_special_modulus, true, destination, u_destination, e_destination, seed, pool);
         }
 
         /**
@@ -456,31 +458,46 @@ namespace seal
         Encryptor &operator=(Encryptor &&assign) = delete;
 
         void encrypt_zero_internal(
-            parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
+            parms_id_type parms_id,
+            bool is_asymmetric,
+            bool save_seed, 
             Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
+            MemoryPoolHandle pool = MemoryManager::GetPool()
+        ) const;
 
         void encrypt_zero_internal(
-            parms_id_type parms_id, bool is_asymmetric, bool save_seed, 
+            parms_id_type parms_id,
+            bool is_asymmetric,
+            bool save_seed, 
             bool disable_special_modulus,
-            bool export_noise, Ciphertext &destination,
-            PolynomialArray &u_destination,
-            PolynomialArray &e_destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
-
-        void encrypt_internal(
-            const Plaintext &plain, bool is_asymmetric, bool save_seed, 
-            Ciphertext &destination, 
-            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
-
-        void encrypt_internal(
-            const Plaintext &plain, bool is_asymmetric, bool save_seed, 
-            bool disable_special_modulus,
-            bool export_noise, 
+            bool export_components,
             Ciphertext &destination,
             PolynomialArray &u_destination,
             PolynomialArray &e_destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
+            std::optional<prng_seed_type> seed = std::nullopt,
+            MemoryPoolHandle pool = MemoryManager::GetPool()
+        ) const;
+
+        void encrypt_internal(
+            const Plaintext &plain,
+            bool is_asymmetric,
+            bool save_seed, 
+            Ciphertext &destination, 
+            MemoryPoolHandle pool = MemoryManager::GetPool()
+        ) const;
+
+        void encrypt_internal(
+            const Plaintext &plain,
+            bool is_asymmetric,
+            bool save_seed, 
+            bool disable_special_modulus,
+            bool export_components, 
+            Ciphertext &destination,
+            PolynomialArray &u_destination,
+            PolynomialArray &e_destination,
+            std::optional<prng_seed_type> seed = std::nullopt,
+            MemoryPoolHandle pool = MemoryManager::GetPool()
+        ) const;
 
         SEALContext context_;
 

--- a/native/src/seal/util/rlwe.cpp
+++ b/native/src/seal/util/rlwe.cpp
@@ -230,9 +230,16 @@ namespace seal
             // c[j] = public_key[j] * u + e[j] in BFV/CKKS = public_key[j] * u + p * e[j] in BGV
             // where e[j] <-- chi, u <-- R_3
 
+            
+            // Note: if you need to seed this encryption with a known value,
+            // then this code can be uncommented. Otherwise we do not actually
+            // use the seed if it is provided to ensure the library is not
+            // accidentally insecure.
+            // auto prng = seed.has_value() ? parms.random_generator()->create(seed.value())
+            //                              : parms.random_generator()->create();
+
             // Create a PRNG; u and the noise/error share the same PRNG
-            auto prng = seed.has_value() ? parms.random_generator()->create(seed.value())
-                                         : parms.random_generator()->create();
+            auto prng = parms.random_generator()->create();
 
             // Generate u <-- R_3
             auto u(allocate_poly(coeff_count, coeff_modulus_size, pool));
@@ -348,12 +355,19 @@ namespace seal
             destination.scale() = 1.0;
             destination.correction_factor() = 1;
 
+
+            // Note: if you need to seed this encryption with a known value,
+            // then this code can be uncommented. Otherwise we do not actually
+            // use the seed if it is provided to ensure the library is not
+            // accidentally insecure.
+            // auto bootstrap_prng = seed.has_value() 
+            //      ? parms.random_generator()->create(seed.value())
+            //      : parms.random_generator()->create();
+
             // Create an instance of a random number generator. We use this for sampling
             // a seed for a second PRNG used for sampling u (the seed can be public
             // information. This PRNG is also used for sampling the noise/error below.
-            auto bootstrap_prng = seed.has_value() 
-                 ? parms.random_generator()->create(seed.value())
-                 : parms.random_generator()->create();
+            auto bootstrap_prng = parms.random_generator()->create();
 
             // Sample a public seed for generating uniform randomness
             prng_seed_type public_prng_seed;

--- a/native/src/seal/util/rlwe.cpp
+++ b/native/src/seal/util/rlwe.cpp
@@ -227,10 +227,10 @@ namespace seal
             destination.scale() = 1.0;
             destination.correction_factor() = 1;
 
-            // c[j] = public_key[j] * u + e[j] in BFV/CKKS = public_key[j] * u + p * e[j] in BGV
+            // c[j] = public_key[j] * u + e[j] in BFV/CKKS 
+            //      = public_key[j] * u + p * e[j] in BGV
             // where e[j] <-- chi, u <-- R_3
 
-            
             // Note: if you need to seed this encryption with a known value,
             // then this code can be uncommented. Otherwise we do not actually
             // use the seed if it is provided to ensure the library is not
@@ -274,7 +274,8 @@ namespace seal
             }
 
             // Generate e_j <-- chi
-            // c[j] = public_key[j] * u + e[j] in BFV/CKKS, = public_key[j] * u + p * e[j] in BGV,
+            // c[j] = public_key[j] * u + e[j] in BFV/CKKS,
+            //      = public_key[j] * u + p * e[j] in BGV,
             for (size_t j = 0; j < encrypted_size; j++)
             {
                 // u is being modified in place to add some error terms.
@@ -354,7 +355,6 @@ namespace seal
             destination.is_ntt_form() = is_ntt_form;
             destination.scale() = 1.0;
             destination.correction_factor() = 1;
-
 
             // Note: if you need to seed this encryption with a known value,
             // then this code can be uncommented. Otherwise we do not actually

--- a/native/src/seal/util/rlwe.cpp
+++ b/native/src/seal/util/rlwe.cpp
@@ -12,6 +12,7 @@
 #include "seal/util/polyarithsmallmod.h"
 #include "seal/util/polycore.h"
 #include "seal/util/rlwe.h"
+#include <optional>
 
 using namespace std;
 
@@ -194,10 +195,11 @@ namespace seal
             const SEALContext &context, 
             parms_id_type parms_id, 
             bool is_ntt_form,
-            bool export_noise,
+            bool export_components,
             Ciphertext &destination, 
             PolynomialArray &u_destination,
-            PolynomialArray &e_destination
+            PolynomialArray &e_destination,
+            optional<prng_seed_type> seed
         ) {
 #ifdef SEAL_DEBUG
             if (!is_valid_for(public_key, context))
@@ -229,13 +231,14 @@ namespace seal
             // where e[j] <-- chi, u <-- R_3
 
             // Create a PRNG; u and the noise/error share the same PRNG
-            auto prng = parms.random_generator()->create();
+            auto prng = seed.has_value() ? parms.random_generator()->create(seed.value())
+                                         : parms.random_generator()->create();
 
             // Generate u <-- R_3
             auto u(allocate_poly(coeff_count, coeff_modulus_size, pool));
             sample_poly_ternary(prng, parms, u.get());
 
-            if (export_noise) {
+            if (export_components) {
                 u_destination.reserve(1, coeff_count, coeff_modulus);
                 u_destination.insert_polynomial(0, u.get());
             }
@@ -259,7 +262,7 @@ namespace seal
                 }
             }
 
-            if (export_noise) {
+            if (export_components) {
                 e_destination.reserve(encrypted_size, coeff_count, coeff_modulus);
             }
 
@@ -271,7 +274,7 @@ namespace seal
                 SEAL_NOISE_SAMPLER(prng, parms, u.get());
                 RNSIter gaussian_iter(u.get(), coeff_count);
 
-                if (export_noise) {
+                if (export_components) {
                     e_destination.insert_polynomial(j, u.get());
                 }
 
@@ -298,8 +301,14 @@ namespace seal
         }
 
         void encrypt_zero_symmetric(
-            const SecretKey &secret_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
-            bool save_seed, Ciphertext &destination)
+            const SecretKey &secret_key, 
+            const SEALContext &context, 
+            parms_id_type parms_id, 
+            bool is_ntt_form,
+            bool save_seed, 
+            Ciphertext &destination,
+            optional<prng_seed_type> seed
+        )
         {
 #ifdef SEAL_DEBUG
             if (!is_valid_for(secret_key, context))
@@ -342,7 +351,9 @@ namespace seal
             // Create an instance of a random number generator. We use this for sampling
             // a seed for a second PRNG used for sampling u (the seed can be public
             // information. This PRNG is also used for sampling the noise/error below.
-            auto bootstrap_prng = parms.random_generator()->create();
+            auto bootstrap_prng = seed.has_value() 
+                 ? parms.random_generator()->create(seed.value())
+                 : parms.random_generator()->create();
 
             // Sample a public seed for generating uniform randomness
             prng_seed_type public_prng_seed;

--- a/native/src/seal/util/rlwe.h
+++ b/native/src/seal/util/rlwe.h
@@ -96,6 +96,10 @@ namespace seal
         @param[out] destination The output ciphertext - an encryption of zero
         @param[out] u The u component.
         @param[out] e The e component.
+        @param[in] (Optional) Set seed for a deterministic encryption. NOTE:
+        while one can provide this parameter, it is currently disabled in the
+        encryption function. If you want to provide a seed, you will need to
+        uncomment code in this function's definition.
         */
         void encrypt_zero_asymmetric(
             const PublicKey &public_key, 
@@ -119,6 +123,10 @@ namespace seal
         @param[in] is_ntt_form If true, store ciphertext in NTT form
         @param[in] save_seed If true, the second component of ciphertext is
         replaced with the random seed used to sample this component
+        @param[in] (Optional) Set seed for a deterministic encryption. NOTE:
+        while one can provide this parameter, it is currently disabled in the
+        encryption function. If you want to provide a seed, you will need to
+        uncomment code in this function's definition.
         */
         void encrypt_zero_symmetric(
             const SecretKey &secret_key, 

--- a/native/src/seal/util/rlwe.h
+++ b/native/src/seal/util/rlwe.h
@@ -11,6 +11,7 @@
 #include "seal/randomgen.h"
 #include "seal/secretkey.h"
 #include <cstdint>
+#include <optional>
 
 namespace seal
 {
@@ -91,17 +92,21 @@ namespace seal
         @param[in] context The SEALContext containing a chain of ContextData
         @param[in] parms_id Indicates the level of encryption
         @param[in] is_ntt_form If true, store ciphertext in NTT form
-        @param[in] export_noise Whether to export the ciphertext noise inputs (u, e_i)
+        @param[in] export_components Whether to export the ciphertext components (u, e_i)
         @param[out] destination The output ciphertext - an encryption of zero
-        @param[out] u The u noise value.
-        @param[out] e The u noise value.
+        @param[out] u The u component.
+        @param[out] e The e component.
         */
         void encrypt_zero_asymmetric(
-            const PublicKey &public_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
-            bool export_noise,
+            const PublicKey &public_key, 
+            const SEALContext &context, 
+            parms_id_type parms_id, 
+            bool is_ntt_form,
+            bool export_components,
             Ciphertext &destination,
             PolynomialArray &u_destination,
-            PolynomialArray &e_destination
+            PolynomialArray &e_destination,
+            std::optional<prng_seed_type> seed = std::nullopt
         );
 
         /**
@@ -116,7 +121,13 @@ namespace seal
         replaced with the random seed used to sample this component
         */
         void encrypt_zero_symmetric(
-            const SecretKey &secret_key, const SEALContext &context, parms_id_type parms_id, bool is_ntt_form,
-            bool save_seed, Ciphertext &destination);
+            const SecretKey &secret_key, 
+            const SEALContext &context, 
+            parms_id_type parms_id, 
+            bool is_ntt_form,
+            bool save_seed, 
+            Ciphertext &destination,
+            std::optional<prng_seed_type> seed = std::nullopt
+        );
     } // namespace util
 } // namespace seal

--- a/native/tests/seal/encryptor.cpp
+++ b/native/tests/seal/encryptor.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
+#include <optional>
 #include "gtest/gtest.h"
 
 using namespace seal;


### PR DESCRIPTION
Enables a seed to be optionally set when encrypting a value. This allows for deterministic encryptions for debugging purposes.

Also renames "export_noise" to "export_components", plus some whitespace style changes.