### PR TITLE
Polyarrays created from ciphertexts/public keys are converted out of NTT on creation

### DIFF
--- a/native/src/seal/c/polyarray.cpp
+++ b/native/src/seal/c/polyarray.cpp
@@ -206,3 +206,24 @@ SEAL_C_FUNC PolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size) {
     *size = poly_array->coeff_modulus_size();
     return S_OK;
 }
+
+SEAL_C_FUNC PolynomialArray_Drop(void *thisptr, void **poly_array)
+{
+    PolynomialArray *this_array = FromVoid<PolynomialArray>(thisptr);
+    IfNullRet(this_array, E_POINTER);
+
+    IfNullRet(poly_array, E_POINTER);
+    try
+    {
+        PolynomialArray result = this_array->drop();
+
+        // Move to the heap
+        PolynomialArray *return_array = new PolynomialArray(result);
+        *poly_array = return_array;
+        return S_OK;
+    }
+    catch (const invalid_argument &)
+    {
+        return E_INVALIDARG;
+    }
+}

--- a/native/src/seal/c/polyarray.h
+++ b/native/src/seal/c/polyarray.h
@@ -36,3 +36,5 @@ SEAL_C_FUNC PolynomialArray_PolySize(void *thisptr, uint64_t *size);
 SEAL_C_FUNC PolynomialArray_PolyModulusDegree(void *thisptr, uint64_t *size);
 
 SEAL_C_FUNC PolynomialArray_CoeffModulusSize(void *thisptr, uint64_t *size);
+
+SEAL_C_FUNC PolynomialArray_Drop(void *thisptr, void **poly_array);

--- a/native/src/seal/polyarray.cpp
+++ b/native/src/seal/polyarray.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "seal/polyarray.h"
+#include <algorithm>
 
 using namespace seal::util;
 
@@ -32,6 +33,8 @@ namespace seal
             insert_polynomial(i, data_ptr);
         }
 
+        // Convert out of NTT form for each polynomial. For BFV, this should not
+        // be necessary.
         if (is_ntt_form) {
             for (size_t i = 0; i < coeff_modulus_size; i++) {
                 for (size_t j = 0; j < num_poly; j++) {
@@ -49,9 +52,9 @@ namespace seal
     ) : PolynomialArray(pool) {
 
         auto &ciphertext = public_key.data();
-        auto &parms = context.key_context_data()->parms();
+        auto &parms = context.first_context_data()->parms();
         auto &coeff_modulus = parms.coeff_modulus();
-        auto coeff_modulus_size = ciphertext.coeff_modulus_size();
+        auto coeff_modulus_size = coeff_modulus.size();
         auto poly_modulus_degree = ciphertext.poly_modulus_degree();
         auto num_poly = ciphertext.size();
 
@@ -65,10 +68,11 @@ namespace seal
         // The ciphertexts are stored in the same RNS format as the
         // other polynomial arrays.
         for (int i = 0; i < num_poly; i++) {
-            const auto data_ptr = ciphertext.data() + i * (poly_modulus_degree * coeff_modulus_size);
+            const auto data_ptr = public_key.data().data(i);
             insert_polynomial(i, data_ptr);
         }
 
+        // Convert out of NTT form for each polynomial.
         if (is_ntt_form) {
             for (size_t i = 0; i < coeff_modulus_size; i++) {
                 for (size_t j = 0; j < num_poly; j++) {
@@ -148,5 +152,29 @@ namespace seal
         }
 
         is_rns_ = true;
+    }
+
+    /**
+    Switches the polynomial array down one modulus by dropping the last modulus
+    in the set.
+    */
+    PolynomialArray PolynomialArray::drop() const {
+        auto lower_modulus = rnsbase_.get()->drop();
+        auto new_coeff_modulus_size = lower_modulus.size();
+        std::vector<Modulus> lower_modulus_values(lower_modulus.size());
+
+        for (std::size_t i = 0; i < lower_modulus.size(); i++) {
+            lower_modulus_values[i] = lower_modulus[i];
+        }
+
+        auto new_len = poly_size_ * coeff_size_ * new_coeff_modulus_size;
+
+        PolynomialArray poly_array(pool_);
+        poly_array.reserve(poly_size_, coeff_size_, lower_modulus_values);
+
+        std::copy_n(data_.get(), new_len, poly_array.data_.get());
+        poly_array.polynomial_reserved_ = polynomial_reserved_;
+
+        return poly_array;
     }
 }

--- a/native/src/seal/polyarray.h
+++ b/native/src/seal/polyarray.h
@@ -234,6 +234,11 @@ namespace seal
                     util::set_uint(data_.get(), len_, data);
                 }
 
+                /**
+                Switches the polynomial array down one modulus by dropping the
+                last modulus in the set.
+                */
+                PolynomialArray drop() const;
 
             private:
                 // We make an independent function instead of setting on

--- a/native/src/seal/publickey.h
+++ b/native/src/seal/publickey.h
@@ -248,6 +248,14 @@ namespace seal
         }
 
         /**
+        Returns whether the ciphertext is in NTT form.
+        */
+        SEAL_NODISCARD inline bool is_ntt_form() const noexcept
+        {
+            return pk_.is_ntt_form();
+        }
+
+        /**
         Enables access to private members of seal::PublicKey for SEAL_C.
         */
         struct PublicKeyPrivateHelper;


### PR DESCRIPTION
Public keys were always stored in NTT form, and hence need to be converted out of that form in order to use them with other components that are also not in NTT form.

Additionally adds a predicate to determine if a public key is in NTT form. This should always be true but can be a good check to ensure that if the public key is converted at any point that it should be returned back to NTT form.